### PR TITLE
Uncoloured print when attaching STDOUT to a pipe

### DIFF
--- a/dbc_search
+++ b/dbc_search
@@ -114,8 +114,12 @@ foreach my $server ( @these_servers ) {
     chomp @dbs;
     shift @dbs;
     foreach my $dbname ( @dbs ) {
-    	print( colored( ['', 'cyan', ''], "$server" ) );
-    	print " $dbname\n";
+        if (-p STDOUT) {
+            print "$server $dbname\n";
+        } else {
+            print( colored( ['', 'cyan', ''], "$server" ) );
+            print " $dbname\n";
+        }
     }
     # print join("\n", map {"$server $_"} @dbs);
     print "\n";


### PR DESCRIPTION
This option allows this script to make it part of a pipeline, removing the coloured part of the output. For instance, `dbc_search ${USER} | xargs -I % sh -c 'echo %'` wasn't possible before this change.